### PR TITLE
OS selection

### DIFF
--- a/apb.yml
+++ b/apb.yml
@@ -39,3 +39,8 @@ plans:
         type: string
         required: true
         display_type: password
+      - title: Operating system type
+        name: os_type
+        default: linux
+        enum: ['linux', 'windows']
+        type: enum

--- a/roles/provision-v2v/tasks/main.yml
+++ b/roles/provision-v2v/tasks/main.yml
@@ -1,4 +1,4 @@
 - include: "login.yml"
 
 - name: execute run script
-  shell: ./run.sh {{ vm_name }} {{ username }} {{ password }} {{ url }}
+  shell: ./run.sh {{ vm_name }} {{ username }} {{ password }} {{ url }} {{ os_type }}


### PR DESCRIPTION
We want to select OS type before importing the vm. This is a workaround
for issues with have with os short-id.